### PR TITLE
Encapsulate Parser Implementation

### DIFF
--- a/klvp/TestKLVParser.cpp
+++ b/klvp/TestKLVParser.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 TestKLVParser::TestKLVParser(KLVPrintVisitor& printer)
 	: count_(0)
-	, type_(lcss::KLVParser::TYPE::LOCAL_SET)
+	, type_(lcss::TYPE::LOCAL_SET)
 	, printVisitor_(printer)
 {
 	//Validate Checksum
@@ -22,23 +22,23 @@ TestKLVParser::~TestKLVParser(void)
 {
 }
 
-void TestKLVParser::onBeginSet(int len, lcss::KLVParser::TYPE type)
+void TestKLVParser::onBeginSet(int len, lcss::TYPE type)
 {
 	lcss::KLVParser::onBeginSet(len,type);
 	type_ = type;
 
 	switch (type_)
 	{
-	case TYPE::LOCAL_SET:
+	case lcss::TYPE::LOCAL_SET:
 		std::cout << "\t<Local_Set length=\"" << len << "\" count=\"" << count_++ << "\">" << endl;
 		break;
-	case TYPE::UNIVERSAL_SET:
+	case lcss::TYPE::UNIVERSAL_SET:
 		std::cout << "\t<Universal_Set length=\"" << len << "\" count=\"" << count_++ << "\">" << endl;
 		break;
-	case TYPE::SECURITY_UNIVERSAL_SET:
+	case lcss::TYPE::SECURITY_UNIVERSAL_SET:
 		std::cout << "\t<Security_Universal_Set length=\"" << len << "\" count=\"" << count_++ << "\">" << endl;
 		break;
-	case TYPE::UNIVERSAL_ELEMENT:
+	case lcss::TYPE::UNIVERSAL_ELEMENT:
 		std::cout << "\t<Universal_Element length=\"" << len << "\" count=\"" << count_++ << "\">" << endl;
 		break;
 	}
@@ -51,10 +51,10 @@ void TestKLVParser::onEndSet()
 
 	switch (type_)
 	{
-	case TYPE::LOCAL_SET: std::cout << "\t</Local_Set>" << std::endl; break;
-	case TYPE::UNIVERSAL_SET: std::cout << "\t</Universal_Set>" << std::endl; break;
-	case TYPE::SECURITY_UNIVERSAL_SET: std::cout << "\t</Security_Universal_Set>" << std::endl; break;
-	case TYPE::UNIVERSAL_ELEMENT: std::cout << "\t</Universal_Element>" << std::endl; break;
+	case lcss::TYPE::LOCAL_SET: std::cout << "\t</Local_Set>" << std::endl; break;
+	case lcss::TYPE::UNIVERSAL_SET: std::cout << "\t</Universal_Set>" << std::endl; break;
+	case lcss::TYPE::SECURITY_UNIVERSAL_SET: std::cout << "\t</Security_Universal_Set>" << std::endl; break;
+	case lcss::TYPE::UNIVERSAL_ELEMENT: std::cout << "\t</Universal_Element>" << std::endl; break;
 	}
 	
 }

--- a/klvp/TestKLVParser.h
+++ b/klvp/TestKLVParser.h
@@ -9,7 +9,7 @@ public:
 	TestKLVParser(KLVPrintVisitor& printer);
 	virtual ~TestKLVParser(void);
 
-	virtual void onBeginSet(int len, lcss::KLVParser::TYPE type);
+	virtual void onBeginSet(int len, lcss::TYPE type);
 	virtual void onElement( lcss::KLVElement& klv);
 	virtual void onEndSet();
 	virtual void onError(const char* errmsg, int pos);
@@ -18,7 +18,7 @@ public:
 
 private:
 	int						count_;
-	lcss::KLVParser::TYPE	type_;
+	lcss::TYPE	type_;
 	KLVPrintVisitor&		printVisitor_;
 };
 

--- a/klvp/TestKLVSecuritySetParser.cpp
+++ b/klvp/TestKLVSecuritySetParser.cpp
@@ -17,7 +17,7 @@ TestKLVSecuritySetParser::~TestKLVSecuritySetParser(void)
 {
 }
 
-void TestKLVSecuritySetParser::onBeginSet(int len, lcss::KLVParser::TYPE type)
+void TestKLVSecuritySetParser::onBeginSet(int len, lcss::TYPE type)
 {
 	lcss::KLVParser::onBeginSet(len, type);
 	std::cout << "\t\t<LDS_Security_Set length=\"" << len  << "\">" << endl;

--- a/klvp/TestKLVSecuritySetParser.h
+++ b/klvp/TestKLVSecuritySetParser.h
@@ -9,7 +9,7 @@ public:
 	TestKLVSecuritySetParser(void);
 	virtual ~TestKLVSecuritySetParser(void);
 
-	virtual void onBeginSet(int len, lcss::KLVParser::TYPE type);
+	virtual void onBeginSet(int len, lcss::TYPE type);
 	virtual void onElement( lcss::KLVElement& klv);
 	virtual void onEndSet();
 	virtual void onError(const char* errmsg, int pos);

--- a/libklvp/klvelmt.cpp
+++ b/libklvp/klvelmt.cpp
@@ -232,6 +232,21 @@ int lcss::KLVElement::length() const
 	return 0;
 }
 
+int lcss::KLVElement::numOfBytesForLength() const
+{
+	if (pimpl_.get() != nullptr)
+	{
+		int sz = pimpl_->length();
+		if (sz < 0x7F)
+			return 1;
+		else if (sz > 0x7F && sz < 0x0100)
+			return 2;
+		else
+			return 3;
+	}
+	return 0;
+}
+
 void lcss::KLVElement::value(uint8_t* buf) const
 {
 	if (pimpl_.get() != nullptr)

--- a/libklvp/klvelmt.h
+++ b/libklvp/klvelmt.h
@@ -49,11 +49,20 @@ public:
 	/// Retrieve KLV element's key in the serialized BER-OID form.
 	/// </summary>
 	/// <param name="key">The buffer to hold the serialized bytes</param>
-	/// <returns>The number of bytes to hold the key. If input paramater is null
+	/// <returns>The number of bytes to hold the key. If input parameter is null
 	/// return the number of bytes without filling input parameter.</returns>
 	int key(uint8_t* key) const;
 
 	int length() const;
+
+	/// <summary>
+	/// Returns the number of bytes used to encode the length field
+	/// using BER encoding.
+	/// Ref: MISB ST 0107.3, Section 6.3.2, 1 November 2018
+	/// </summary>
+	/// <returns>Number of bytes used to BER encoded the length; otherwise,
+	///  return 0 for error.</returns>
+	int numOfBytesForLength() const;
 
 	void value(uint8_t*) const;
 	uint8_t* value();


### PR DESCRIPTION
- Hide the KLV parsers implementation using the Pimpl idiom.
- Updated klvp test application because of interface changes in the KLV parser.
- Added a new member function in KLVElement, numOfBytesForLength(), which returns the number of bytes used to BER encode the length field.