### PR TITLE
Build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,20 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (klvp
-	VERSION 1.0.0
-	DESCRIPTION "STANAG 4609 ST 0601 KLV Parser Library"
-	LANGUAGES C CXX
+  VERSION 1.0.0
+  DESCRIPTION "STANAG 4609 ST 0601 KLV Parser Library"
+  LANGUAGES C CXX
 )
 
 # Include sub-projects.
 add_subdirectory (klvp)
 add_subdirectory (ldsdb)
 
-# Create an app that reads KLV encode stream and outputs XML representation.
+# Create an app, klv2xml, that reads KLV encode stream and outputs XML representation.
 add_executable(klv2xml)
 
-target_sources(klv2xml PRIVATE
+target_sources(klv2xml
+  PRIVATE
     src/klvp.h
     src/klvp.cpp
     src/KLVPrintVisitor.h
@@ -29,11 +30,18 @@ target_sources(klv2xml PRIVATE
     src/TestKLVSecuritySetParser.cpp
 )
 
-if(NOT WIN32)
-    list(APPEND EXTRA_LIBS uuid)
-endif()
+target_link_libraries(klv2xml
+  PRIVATE
+    klvp
+    ldsdb
+)
 
-target_link_libraries(klv2xml PRIVATE klvp ldsdb ${EXTRA_LIBS})
+if(NOT WIN32)
+target_link_libraries(klv2xml
+  PRIVATE
+    uuid
+)
+endif()
 
 # install
 install (TARGETS klv2xml)
@@ -41,9 +49,9 @@ install (TARGETS klv2xml)
 # Test cases
 enable_testing()
 
-set(args ${PROJECT_SOURCE_DIR}/sample/svt_testset_420_720p50_klved_4774.klv ${PROJECT_SOURCE_DIR}/data/klv.s3db)
 add_test(NAME read_test 
-    COMMAND klv2xml ${args}
+  COMMAND klv2xml ${PROJECT_SOURCE_DIR}/sample/svt_testset_420_720p50_klved_4774.klv ${PROJECT_SOURCE_DIR}/data/klv.s3db
 )
 set_tests_properties(read_test
-    PROPERTIES PASS_REGULAR_EXPRESSION "KLV count = 2503")
+  PROPERTIES PASS_REGULAR_EXPRESSION "KLV count = 2503"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,7 @@ target_link_libraries(klv2xml
 )
 
 if(NOT WIN32)
-target_link_libraries(klv2xml
-  PRIVATE
-    uuid
-)
+target_link_libraries(klv2xml PRIVATE uuid)
 endif()
 
 # install

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project requires the following to be installed:
 2. Microsoft Guidelines Support Library (GSL), https://github.com/microsoft/GSL 
 3. SQLite3, https://github.com/sqlite/sqlite
 
-It is recommended to use a package managment system such as [vcpkg](https://github.com/microsoft/vcpkg) to download and install __GSL__ and __SQLite3__.
+It is recommended to use a package management system such as [vcpkg](https://github.com/microsoft/vcpkg) to download and install __GSL__ and __SQLite3__.
 
 ## To Build and Install
 In __klvp__ root directory, build and install this project using CMake with the following commmands on a terminal:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 # klvp
-STANAG 4609 ST 0601 Key-Length-Value (KLV) parser library
+STANAG 4609 ST 0601 Key-Length-Value (KLV) parser library and test application, __klv2xml__, 
+which reads in KLV encoded stream and writes out an XML representation.
+
+## Prerequisites
+This project requires the following to be installed:
+
+1. CMake, https://cmake.org/
+2. Microsoft Guidelines Support Library (GSL), https://github.com/microsoft/GSL 
+3. SQLite3, https://github.com/sqlite/sqlite
+
+It is recommended to use a package managment system such as [vcpkg](https://github.com/microsoft/vcpkg) to download and install __GSL__ and __SQLite3__.
 
 ## To Build and Install
 In __klvp__ root directory, build and install this project using CMake with the following commmands on a terminal:
 
 ### 1. Generate the build environment
     cmake -S . -B ./build 
+    
+If you installed __GSL__ and __SQLite3__ using __vcpkg__, you may need to add `-DCMAKE_PREFIX_PATH=[vcpkg root]/installed/[target]` as an argument to the above command. 
+The `[target]` is the target machine architecture such as `x64-windows` or `x64-linux`.
+
 ### 2. Build the library and test application
     cmake --build ./build 
 ### 3. Install the KLV Parser library
     cmake --install ./build
 
-Add additional CMake parameters as required depending on your host development envirnoment.
+Add additional CMake parameters as required depending on your host development envirnoment. 
 
 The `--install` command will install a CMake package so it can be imported into other CMake projects.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ In __klvp__ root directory, build and install this project using CMake with the 
 ### 1. Generate the build environment
     cmake -S . -B ./build 
     
-If you installed __GSL__ and __SQLite3__ using __vcpkg__, you may need to add `-DCMAKE_PREFIX_PATH=[vcpkg root]/installed/[target]` as an argument to the above command. 
+If you installed __GSL__ and __SQLite3__ using __vcpkg__, you may need to add 
+
+    -DCMAKE_PREFIX_PATH=[vcpkg root]/installed/[target]
+    
+as an argument to the above __cmake__ command. 
 The `[target]` is the target machine architecture such as `x64-windows` or `x64-linux`.
 
 ### 2. Build the library and test application

--- a/klvp/CMakeLists.txt
+++ b/klvp/CMakeLists.txt
@@ -9,7 +9,7 @@ include(GNUInstallDirs)
 
 # This is the default install directory for config-file package cmake files
 # It is relative to install prefix.
-set(klvp_INSTALL_CMAKEDIR cmake CACHE PATH "Installation directory for config-file package cmake files")
+set(klvp_INSTALL_CMAKEDIR lib/cmake/klvp CACHE PATH "Installation directory for config-file package cmake files")
 
 # set the postfix "d" for the resulting .so or .dll files when building the
 # library in debug mode
@@ -32,8 +32,6 @@ ExternalProject_Get_Property(loki-lib SOURCE_DIR)
 
 set(LOKI_DIR "${SOURCE_DIR}")
 
-include_directories(${LOKI_DIR}/include)
-
 include(FetchContent)
 
 FetchContent_Declare(GSL
@@ -46,7 +44,7 @@ FetchContent_MakeAvailable(GSL)
 
 set(GSL_SRC_DIR ${gsl_SOURCE_DIR})
 
-include_directories(${GSL_SRC_DIR}/include)
+#include_directories(${GSL_SRC_DIR}/include)
 
 add_library(klvp STATIC)
 
@@ -99,7 +97,7 @@ target_link_libraries(klvp
 target_include_directories(klvp
     PRIVATE src/klvp
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    INTERFACE $<BUILD_INTERFACE:${LOKI_DIR}/include>
+    PUBLIC $<BUILD_INTERFACE:${LOKI_DIR}/include>
 )
 
 install (TARGETS klvp

--- a/klvp/CMakeLists.txt
+++ b/klvp/CMakeLists.txt
@@ -67,10 +67,7 @@ add_dependencies(klvp loki-lib)
 # specify the C++ standard
 target_compile_features( klvp PUBLIC cxx_std_14)
 
-target_link_libraries(klvp
-  INTERFACE
-    $<BUILD_LOCAL_INTERFACE:Microsoft.GSL::GSL>
-)
+target_link_libraries(klvp PUBLIC Microsoft.GSL::GSL)
 
 if (WIN32)
 target_link_libraries(klvp PRIVATE wsock32 ws2_32)

--- a/klvp/CMakeLists.txt
+++ b/klvp/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required (VERSION 3.26)
 
 project(klvp
-    VERSION 1.0.0
-    DESCRIPTION "STANAG 4609 ST 0601 KLV parser library"
-    LANGUAGES C CXX)
+  VERSION 1.0.0
+  DESCRIPTION "STANAG 4609 ST 0601 KLV parser library"
+  LANGUAGES C CXX
+)
 
 include(GNUInstallDirs)
 
@@ -48,7 +49,8 @@ set(GSL_SRC_DIR ${gsl_SOURCE_DIR})
 
 add_library(klvp STATIC)
 
-target_sources(klvp PRIVATE
+target_sources(klvp
+  PRIVATE
     src/decode.cpp
     src/encode.cpp
     src/FpParser.cpp
@@ -85,19 +87,24 @@ target_compile_features(
     PUBLIC cxx_std_14
 )
 
-if(WIN32)
-    set(WS wsock32 ws2_32)
-endif()
-
 target_link_libraries(klvp
-    PRIVATE ${WS}
-    INTERFACE $<BUILD_LOCAL_INTERFACE:Microsoft.GSL::GSL>
+  INTERFACE
+    $<BUILD_LOCAL_INTERFACE:Microsoft.GSL::GSL>
 )
 
+if (WIN32)
+target_link_libraries(klvp
+  PRIVATE
+    wsock32 ws2_32
+)
+endif()
+
 target_include_directories(klvp
-    PRIVATE src/klvp
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    PUBLIC $<BUILD_INTERFACE:${LOKI_DIR}/include>
+  PRIVATE 
+    src/klvp
+  PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${LOKI_DIR}/include>
 )
 
 install (TARGETS klvp
@@ -113,7 +120,7 @@ install (
 install (EXPORT klvp_export
     FILE klvp-config.cmake
     NAMESPACE lcss::
-    DESTINATION ${klvp_INSTALL_CMAKEDIR}
+    DESTINATION lib/cmake/klvp
 )
 
 # Defines write_basic_package_version_file
@@ -134,5 +141,5 @@ write_basic_package_version_file(
 # in the same directory as `klvp-config.cmake` file.
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/klvp-config-version.cmake"
-  DESTINATION "${klvp_INSTALL_CMAKEDIR}"
+  DESTINATION lib/cmake/klvp
 )

--- a/klvp/CMakeLists.txt
+++ b/klvp/CMakeLists.txt
@@ -8,10 +8,6 @@ project(klvp
 
 include(GNUInstallDirs)
 
-# This is the default install directory for config-file package cmake files
-# It is relative to install prefix.
-set(klvp_INSTALL_CMAKEDIR lib/cmake/klvp CACHE PATH "Installation directory for config-file package cmake files")
-
 # set the postfix "d" for the resulting .so or .dll files when building the
 # library in debug mode
 set(CMAKE_DEBUG_POSTFIX d)
@@ -20,8 +16,7 @@ set(CMAKE_DEBUG_POSTFIX d)
 include(ExternalProject)
 
 # Add an external project from a downloaded source archive
-ExternalProject_Add(
-  loki-lib
+ExternalProject_Add(loki-lib
   URL https://github.com/snaewe/loki-lib/archive/refs/tags/Release_0_1_5.tar.gz
   URL_HASH MD5=74e60c683f745dc15c6e772927349483
   CONFIGURE_COMMAND ""
@@ -33,19 +28,7 @@ ExternalProject_Get_Property(loki-lib SOURCE_DIR)
 
 set(LOKI_DIR "${SOURCE_DIR}")
 
-include(FetchContent)
-
-FetchContent_Declare(GSL
-    GIT_REPOSITORY https://github.com/microsoft/GSL.git
-    GIT_TAG "v4.0.0"
-    GIT_SHALLOW ON
-)
-
-FetchContent_MakeAvailable(GSL)
-
-set(GSL_SRC_DIR ${gsl_SOURCE_DIR})
-
-#include_directories(${GSL_SRC_DIR}/include)
+find_package(Microsoft.GSL CONFIG REQUIRED)
 
 add_library(klvp STATIC)
 
@@ -82,10 +65,7 @@ set_property(TARGET klvp PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(klvp loki-lib)
 
 # specify the C++ standard
-target_compile_features(
-    klvp
-    PUBLIC cxx_std_14
-)
+target_compile_features( klvp PUBLIC cxx_std_14)
 
 target_link_libraries(klvp
   INTERFACE
@@ -93,10 +73,7 @@ target_link_libraries(klvp
 )
 
 if (WIN32)
-target_link_libraries(klvp
-  PRIVATE
-    wsock32 ws2_32
-)
+target_link_libraries(klvp PRIVATE wsock32 ws2_32)
 endif()
 
 target_include_directories(klvp
@@ -108,19 +85,19 @@ target_include_directories(klvp
 )
 
 install (TARGETS klvp
-    EXPORT klvp_export
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  EXPORT klvp_export
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install (
-    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 install (EXPORT klvp_export
-    FILE klvp-config.cmake
-    NAMESPACE lcss::
-    DESTINATION lib/cmake/klvp
+  FILE klvp-config.cmake
+  NAMESPACE lcss::
+  DESTINATION lib/cmake/klvp
 )
 
 # Defines write_basic_package_version_file
@@ -133,6 +110,7 @@ include(CMakePackageConfigHelpers)
 # get it from project(...) version (which is 1.0.0)
 write_basic_package_version_file(
   "klvp-config-version.cmake"
+  VERSION ${klvp_VERSION}
   # Package compatibility strategy. SameMajorVersion is essentially `semantic versioning`.
   COMPATIBILITY SameMajorVersion
 )

--- a/ldsdb/CMakeLists.txt
+++ b/ldsdb/CMakeLists.txt
@@ -22,8 +22,6 @@ ExternalProject_Get_Property(sqlite3 SOURCE_DIR)
 
 set(SQLITE3_DIR "${SOURCE_DIR}")
 
-include_directories(${SQLITE3_DIR}/src)
-
 add_library(ldsdb STATIC)
 
 target_sources(ldsdb PRIVATE
@@ -42,4 +40,7 @@ target_compile_features(
 target_include_directories(ldsdb
     PRIVATE src/ldsdb
     PUBLIC include
+    PRIVATE $<BUILD_INTERFACE:${SQLITE3_DIR}/src>
 )
+
+install(TARGETS ldsdb)

--- a/ldsdb/CMakeLists.txt
+++ b/ldsdb/CMakeLists.txt
@@ -6,21 +6,7 @@ project(ldsdb
   LANGUAGES C CXX
 )
 
-include(GNUInstallDirs)
-
-# include the module `ExternalProject`
-include(ExternalProject)
-
-# Add an external project from a downloaded source archive
-ExternalProject_Add( sqlite3
-  URL https://github.com/alex85k/sqlite3-cmake/archive/refs/tags/v3.24.0.tar.gz
-  URL_HASH MD5=15ab81bf8cfbdb9a9a3b3abd38c7598b
-  BUILD_IN_SOURCE true
-)
-
-ExternalProject_Get_Property(sqlite3 SOURCE_DIR)
-
-set(SQLITE3_DIR "${SOURCE_DIR}")
+find_package(unofficial-sqlite3 CONFIG REQUIRED)
 
 add_library(ldsdb STATIC)
 
@@ -33,17 +19,15 @@ target_sources(ldsdb
 set_property(TARGET ldsdb PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # specify the C++ standard
-target_compile_features( ldsdb
-  PUBLIC 
-    cxx_std_14
-)
+target_compile_features( ldsdb PUBLIC cxx_std_14)
 
 target_include_directories(ldsdb
   PUBLIC
     include
   PRIVATE
     src/ldsdb
-    $<BUILD_INTERFACE:${SQLITE3_DIR}/src>
 )
+
+target_link_libraries(ldsdb PRIVATE unofficial::sqlite3::sqlite3)
 
 install(TARGETS ldsdb)

--- a/ldsdb/CMakeLists.txt
+++ b/ldsdb/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(ldsdb
-    VERSION 1.0.0
-    DESCRIPTION "STANAG 4609 ST 0601 LDS Database library"
-    LANGUAGES C CXX)
+  VERSION 1.0.0
+  DESCRIPTION "STANAG 4609 ST 0601 LDS Database library"
+  LANGUAGES C CXX
+)
 
 include(GNUInstallDirs)
 
@@ -11,8 +12,7 @@ include(GNUInstallDirs)
 include(ExternalProject)
 
 # Add an external project from a downloaded source archive
-ExternalProject_Add(
-  sqlite3
+ExternalProject_Add( sqlite3
   URL https://github.com/alex85k/sqlite3-cmake/archive/refs/tags/v3.24.0.tar.gz
   URL_HASH MD5=15ab81bf8cfbdb9a9a3b3abd38c7598b
   BUILD_IN_SOURCE true
@@ -24,7 +24,8 @@ set(SQLITE3_DIR "${SOURCE_DIR}")
 
 add_library(ldsdb STATIC)
 
-target_sources(ldsdb PRIVATE
+target_sources(ldsdb 
+  PRIVATE
     src/ldsdb.cpp
     include/ldsdb/ldsdb.h
 )
@@ -32,15 +33,17 @@ target_sources(ldsdb PRIVATE
 set_property(TARGET ldsdb PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # specify the C++ standard
-target_compile_features(
-    ldsdb
-    PUBLIC cxx_std_14
+target_compile_features( ldsdb
+  PUBLIC 
+    cxx_std_14
 )
 
 target_include_directories(ldsdb
-    PRIVATE src/ldsdb
-    PUBLIC include
-    PRIVATE $<BUILD_INTERFACE:${SQLITE3_DIR}/src>
+  PUBLIC
+    include
+  PRIVATE
+    src/ldsdb
+    $<BUILD_INTERFACE:${SQLITE3_DIR}/src>
 )
 
 install(TARGETS ldsdb)


### PR DESCRIPTION
Follow modern CMake practices such as avoiding custom variables in project commands.
Use find_package instead of fetching the depended packages.