### PR TITLE
Include sys/time.h

### DIFF
--- a/klvp/include/klvp/encode.h
+++ b/klvp/include/klvp/encode.h
@@ -13,6 +13,8 @@
 #include <loki/Visitor.h>
 #ifdef WIN32
 #include <WinSock2.h>
+#else
+#include <sys/time.h>
 #endif
 
 namespace lcss

--- a/klvp/src/klvprsr.cpp
+++ b/klvp/src/klvprsr.cpp
@@ -76,6 +76,7 @@ namespace lcss
         case TYPE::UNIVERSAL_SET: parser.onBeginSet(len, type_); break;
         case TYPE::SECURITY_UNIVERSAL_SET: parser.onBeginSet(len, type_); break;
         case TYPE::UNIVERSAL_ELEMENT: parser.onBeginSet(len, type_); break;
+        case TYPE::UNKNOWN: parser.onBeginSet(len, type_); break;
         }
     }
 }
@@ -283,7 +284,7 @@ void lcss::KLVParser::onEndSet()
             _pimpl->checksumElement_.value(val);
             memcpy(&cs, val, 2);
             unsigned short localCs = ntohs(cs);
-            if (!(bcc_16(_pimpl->sodb_.begin(), _pimpl->sodb_.end() - 2)) == localCs)
+            if (bcc_16(_pimpl->sodb_.begin(), _pimpl->sodb_.end() - 2) != localCs)
             {
                 onError("Invalid Checksum", 0);
             }

--- a/klvp/src/util.cpp
+++ b/klvp/src/util.cpp
@@ -52,7 +52,7 @@ bool lcss::isLDSGroup(unsigned char key[], int len)
 	{
 		if (i > 15)
 			return false;
-		if (key[i] != lcss::LocalSetKey[i++])
+		if (key[i] != lcss::LocalSetKey[i])
 			return false;
 	}
 	return true;


### PR DESCRIPTION
Include sys/time.h for non-Windows build.
Fixed compiler warnings.