### PR TITLE
Const Correctness

### DIFF
--- a/klvp/include/klvp/klvprsr.h
+++ b/klvp/include/klvp/klvprsr.h
@@ -27,7 +27,7 @@ namespace lcss
         KLVParser(); ///< Default constructor
         virtual ~KLVParser(); ///< class destructor
 
-        virtual void parse(const gsl::span<uint8_t> buffer);
+        virtual void parse(gsl::span<const uint8_t> buffer);
 
         virtual void onBeginSet(int len, TYPE type);
         virtual void onElement(lcss::KLVElement& klv);
@@ -57,7 +57,7 @@ namespace lcss
 
         void onEndSet() override;
 
-        void parse(const gsl::span<uint8_t> buffer) override;
+        void parse(gsl::span<const uint8_t> buffer) override;
     };
 }
 

--- a/klvp/src/klvprsr.cpp
+++ b/klvp/src/klvprsr.cpp
@@ -141,7 +141,7 @@ static int getKLVSetSize(const uint8_t* stream, int sz)
 
 /// @brief Parse a MISB ST 0601 encoded stream in @p buffer.
 /// @param buffer [in] The buffer containing a MISB ST 0601 stream.
-void lcss::KLVParser::parse(const gsl::span<uint8_t> buffer)
+void lcss::KLVParser::parse(gsl::span<const uint8_t> buffer)
 {
     for (const uint8_t& b : buffer)
     {
@@ -340,7 +340,7 @@ void lcss::KLVSecuritySetParser::onEndSet()
 
 }
 
-void lcss::KLVSecuritySetParser::parse(const gsl::span<uint8_t> buffer)
+void lcss::KLVSecuritySetParser::parse(gsl::span<const uint8_t> buffer)
 {
     for (const uint8_t& b : buffer)
     {


### PR DESCRIPTION
Ensure the span passed into parse is const correct.