### PR TITLE
Fix decoding Tag 39 Outside Air Temperature

### DIFF
--- a/klvp/src/decode.cpp
+++ b/klvp/src/decode.cpp
@@ -326,7 +326,9 @@ namespace lcss
 
 	void KLVDecodeVisitor::Visit(lcss::KLVOutsideAirTemperature& klv)
 	{
-		nValue = (int)*klv.value();
+		char temperature;
+		memcpy(&temperature, klv.value(), 1);
+		nValue = (int)temperature;
 	}
 
 	void KLVDecodeVisitor::Visit(lcss::KLVTargetLocationLatitude& klv)


### PR DESCRIPTION
Cast to int from uint8_t doesn't decode negative value correctly.

Example:

Encoded data: -51 (0xCD)

Decoded data: 205 (0x000000CD)

Expected data: -51 (0xFFFFFFCD)

Solution: Copy data to char via memcpy and cast it to int.