### PR TITLE
Fix decoding Tag 45 & 46 Tags Target Error Estimate

### DIFF
--- a/klvp/src/decode.cpp
+++ b/klvp/src/decode.cpp
@@ -369,15 +369,17 @@ namespace lcss
 
 	void KLVDecodeVisitor::Visit(lcss::KLVTargetErrorEstimateCE90& klv)
 	{
-		uint16_t LDS = 0;
-		memcpy(&LDS, klv.value(), 2);
+		uint16_t nVal;
+		memcpy(&nVal, klv.value(), 2);
+		uint16_t LDS = ntohs(nVal);
 		fValue = (4095.0 / 65535.0) * LDS;
 	}
 
 	void KLVDecodeVisitor::Visit(lcss::KLVTargetErrorEstimateLE90& klv)
 	{
-		uint16_t LDS = 0;
-		memcpy(&LDS, klv.value(), 2);
+		uint16_t nVal;
+		memcpy(&nVal, klv.value(), 2);
+		uint16_t LDS = ntohs(nVal);
 		fValue = (4095.0 / 65535.0) * LDS;
 	}
 


### PR DESCRIPTION
Encoded data: 0x2611 (608.9231f)

Decoded data: 0x1126

Expected data: 0x2611

Solution: Just use ntohs